### PR TITLE
Wrong sensor.trakt version

### DIFF
--- a/repos.json
+++ b/repos.json
@@ -177,7 +177,7 @@
     },
     "sensor.trakt": {
       "updated_at": "2018-10-02",
-      "version": "trakt==2.8.2",
+      "version": "0.0.2",
       "local_location": "/custom_components/sensor/trakt.py",
       "remote_location": "https://raw.githubusercontent.com/custom-components/sensor.trakt/master/custom_components/sensor/trakt.py",
       "visit_repo": "https://github.com/custom-components/sensor.trakt",


### PR DESCRIPTION
In the tracker-card I got current: 0.0.2, available: trakt==2.8.2 for sensor.trakt

This seems to be due to the wrong version being specified in this file, so I've changed the version to match what's written in the code.